### PR TITLE
Feature/54 create systemd service for spotify client

### DIFF
--- a/device/spotify-clock-client.service
+++ b/device/spotify-clock-client.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Spotify Clock Client
+
+[Service]
+EnvironmentFile=/usr/local/etc/spotify-clock
+ExecStart=/bin/spotify-clock-client
+
+[Install]
+WantedBy=multi-user.target

--- a/device/spotify-clock-client/src/spotify.rs
+++ b/device/spotify-clock-client/src/spotify.rs
@@ -26,12 +26,18 @@ pub async fn init() -> (Spirc, impl Future<Output=()> + Sized, PlayerEventChanne
     // Create new session
     print!("Connecting session... ");
     // Read credentials
-    let args: Vec<_> = env::args().collect();
-    if args.len() != 3 {
-        eprintln!("Usage: {} USERNAME PASSWORD", args[0]);
+    let mut user = String::new();
+    let mut pass = String::new();
+    match env::var("USER") {
+        Ok(username) => user = username,
+        Err(e) => println!("Unable to retrieve username ({e})"),
+    }
+    match env::var("PASS") {
+        Ok(password) => pass = password,
+        Err(e) => println!("Unable to retrieve password ({e})"),
     }
 
-    let credentials = Credentials::with_password(&args[1], &args[2]);
+    let credentials = Credentials::with_password(user, pass);
     let (session, _) = Session::connect(session_config, credentials, None, false)
         .await
         .unwrap();


### PR DESCRIPTION
credential management is not the safest yet. but this is sufficient for the condition that the service should start without user interaction: This means the credentials need to be stored on the device somehow anyway. Also the device is only accessible within a local network.

resolves #54 